### PR TITLE
Add flag eval permission to permission proto

### DIFF
--- a/api/commons/auth/perms.proto
+++ b/api/commons/auth/perms.proto
@@ -391,6 +391,8 @@ enum Permission {
   PERMISSION_SCORECARDS_MANAGE = 1601 [(annotations.perms.options) = {app: APPLICATION_SCORECARDS}];
   // Enables access to evaluating scorecards.
   PERMISSION_SCORECARDS_EVALUATE = 1602 [(annotations.perms.options) = {app: APPLICATION_SCORECARDS}];
+  // Enables access to evaluating flags.
+  PERMISSION_SCORECARDS_FLAG_EVAL = 1603 [(annotations.perms.options) = {app: APPLICATION_SCORECARDS}];
 
   /*
    * Dev Tools


### PR DESCRIPTION
We're not sure what services (existing or ones that will be made to support this feature, if any) will need this permission, so we'll add them at a later point before this application feature goes live.